### PR TITLE
Add package and docker image publish actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
         tags: ghcr.io/globus-file-handler-cli:1.0.0
         secret-files: |
           "MAVEN_SETTINGS=/home/runner/.m2/settings.xml"
-        file: "docker/crypt4gh/"
+        file: "docker/crypt4gh/Dockerfile"
         build-args: |
             VERSION=1.0.0
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,9 @@
+# This workflow builds a multi-architecture docker image and pushes it to the github container registry
 name: Docker build and push
 
 on:
   release:
-    types: [created]
-  workflow_dispatch:
-  push:
-    branches: [actions]
+    types: [published]
 
 jobs:
   build:
@@ -49,12 +47,12 @@ jobs:
       with:
         push: true
         platforms: "linux/amd64,linux/arm64"
-        tags: ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.0
+        tags: ghcr.io/ebi-gdp/globus-file-handler-cli::${{ github.event.release.tag_name }}
         secret-files: |
           "MAVEN_SETTINGS=/home/runner/.m2/settings.xml"
         file: "docker/crypt4gh/Dockerfile"
         build-args: |
-            VERSION=1.0.0
+            VERSION=${{ github.event.release.tag_name }}
 
     
     

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
   workflow_dispatch:
   push:
-    branches: [actions]
+    branches: [action]
 
 jobs:
   build:
@@ -52,7 +52,7 @@ jobs:
         tags: ghcr.io/globus-file-handler-cli:1.0.0
         secret-files: |
           "MAVEN_SETTINGS=$HOME/.m2/settings.xml"
-        file: "{context}/docker/crypt4gh/"
+        file: "docker/crypt4gh/"
         build-args: |
             VERSION=1.0.0
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         push: true
         platforms: "linux/amd64,linux/arm64"
-        tags: ghcr.io/globus-file-handler-cli:1.0.0
+        tags: ghcr.io/ebi-gdp/globus-file-handler-cli:1.0.0
         secret-files: |
           "MAVEN_SETTINGS=/home/runner/.m2/settings.xml"
         file: "docker/crypt4gh/Dockerfile"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
   workflow_dispatch:
   push:
-    branches: [action]
+    branches: [actions]
 
 jobs:
   build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,62 @@
+name: Docker build and push
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+  push:
+    branches: [dev]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up maven token
+      uses: s4u/maven-settings-action@v3.0.0
+      with:
+        servers: |
+          [{
+            "id": "gitlab-maven",
+            "configuration": {
+              "httpHeaders": {
+                "property": {
+                  "name": "Deploy-Token",
+                  "value": "${{ secrets.MAVEN_TOKEN }}"
+                }
+              }
+            }          
+          }]
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm64
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        push: true
+        platforms: "linux/amd64,linux/arm64"
+        tags: ghcr.io/globus-file-handler-cli:1.0.0
+        secret-files: |
+          "MAVEN_SETTINGS=$HOME/.m2/settings.xml"
+        file: "{context}/docker/crypt4gh/"
+        build-args: |
+            VERSION=1.0.0
+
+    
+    
+
+    

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
   workflow_dispatch:
   push:
-    branches: [dev]
+    branches: [actions]
 
 jobs:
   build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,7 @@ jobs:
         platforms: "linux/amd64,linux/arm64"
         tags: ghcr.io/globus-file-handler-cli:1.0.0
         secret-files: |
-          "MAVEN_SETTINGS=$HOME/.m2/settings.xml"
+          "MAVEN_SETTINGS=/home/runner/.m2/settings.xml"
         file: "docker/crypt4gh/"
         build-args: |
             VERSION=1.0.0

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,34 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -7,6 +7,8 @@ on:
   release:
     types: [created]
   workflow_dispatch:
+  push:
+    branches: [actions]
 
 jobs:
   build:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -20,15 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
-
+  
     - name: Set up maven token
       uses: s4u/maven-settings-action@v3.0.0
       with:
@@ -43,12 +35,18 @@ jobs:
                 }
               }
             }
+          },
+          {
+            "id": "github",
+            "configuration": {
+
+            }
           }]
 
     - name: Build with Maven
       run: mvn clean package
 
-    - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+    - name: Publish package
+      run: mvn --batch-mode deploy
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -34,13 +34,7 @@ jobs:
                   "value": "${{ secrets.MAVEN_TOKEN }}"
                 }
               }
-            }
-          },
-          {
-            "id": "github",
-            "configuration": {
-
-            }
+            }          
           }]
 
     - name: Build with Maven
@@ -49,4 +43,4 @@ jobs:
     - name: Publish package
       run: mvn --batch-mode deploy
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,6 +21,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
   
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+            
     - name: Set up maven token
       uses: s4u/maven-settings-action@v3.0.0
       with:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -34,9 +34,8 @@ jobs:
       with:
         servers: |
           [{
-            "id": "serverId",
+            "id": "gitlab-maven",
             "configuration": {
-              "item1": "value1",
               "httpHeaders": {
                 "property": {
                   "name": "Deploy-Token",

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,8 +5,7 @@ name: Maven Package
 
 on:
   release:
-    types: [created]
-  workflow_dispatch:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -6,6 +6,7 @@ name: Maven Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -16,17 +17,35 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '21'
         distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
+    - name: Set up maven token
+      uses: s4u/maven-settings-action@v3.0.0
+      with:
+        servers: |
+          [{
+            "id": "serverId",
+            "configuration": {
+              "item1": "value1",
+              "httpHeaders": {
+                "property": {
+                  "name": "Deploy-Token",
+                  "value": "${{ secrets.MAVEN_TOKEN }}"
+                }
+              }
+            }
+          }]
+
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn clean package
 
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -7,8 +7,6 @@ on:
   release:
     types: [created]
   workflow_dispatch:
-  push:
-    branches: [actions]
 
 jobs:
   build:

--- a/docker/crypt4gh/Dockerfile
+++ b/docker/crypt4gh/Dockerfile
@@ -1,0 +1,22 @@
+ARG VERSION=1.0.0
+
+FROM maven:eclipse-temurin AS builder
+
+COPY . /tmp/ 
+
+WORKDIR /tmp/
+
+RUN --mount=type=secret,id=MAVEN_SETTINGS mvn clean package -s /run/secrets/MAVEN_SETTINGS
+
+FROM amazoncorretto:22
+
+ARG VERSION
+
+RUN yum install -y procps python3 python3-pip
+
+ENV PIPX_BIN_DIR=/opt/bin/
+
+RUN pip3 install pipx && pipx install crypt4gh && pipx ensurepath
+
+COPY --from=builder /tmp/target/globus-file-handler-cli-${VERSION}.jar /opt/
+

--- a/pom.xml
+++ b/pom.xml
@@ -82,4 +82,12 @@
             </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/ebi-gdp/globus-file-handler-cli</url>
+          </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
When we publish [a new release](https://github.com/ebi-gdp/globus-file-handler-cli/releases):

* Publish [a docker image to the github container registry](https://github.com/ebi-gdp/globus-file-handler-cli/pkgs/container/globus-file-handler-cli)
* Publish a [package with maven to github packages](https://github.com/ebi-gdp/globus-file-handler-cli/packages/2121162)